### PR TITLE
Remove default endpoint

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -14,6 +14,7 @@ provider:
 
   httpApi:
     shouldStartNameWithService: true
+    disableDefaultEndpoint: true
     metrics: true
     cors:
       allowedOrigins:


### PR DESCRIPTION
Since we are using custom domains now, we do not need the default endpoint. 

See https://www.serverless.com/framework/docs/providers/aws/events/http-api#custom-domains