### PR TITLE
Return empty object even when customer not found

### DIFF
--- a/src/app/CustomerService.test.ts
+++ b/src/app/CustomerService.test.ts
@@ -96,7 +96,7 @@ describe(CustomerService.name, () => {
       });
     });
 
-    it("Should return null when the item does not exist", async () => {
+    it("Should return a empty object when the item does not exist", async () => {
       // Arrange
       const { sut } = createTestContext();
 
@@ -104,7 +104,10 @@ describe(CustomerService.name, () => {
       const result = await sut.get("email1");
 
       // Assert
-      expect(result).toBeNull();
+      expect(result).toEqual({
+        email: "email1",
+        lastVisit: null,
+      });
     });
 
     it("Should return map the resulting item", async () => {

--- a/src/app/CustomerService.ts
+++ b/src/app/CustomerService.ts
@@ -38,13 +38,16 @@ export class CustomerService {
   };
 
   get: (email: string) => Promise<Customer | null> = async (email: string) => {
+    const key = { email };
     const result = await this._dbClient
       .get({
         TableName: this._customerTableName,
-        Key: { email },
+        Key: key,
       })
       .promise();
-    return result.Item ? this.mapCustomer(result.Item) : null;
+
+    const item = result.Item || key;
+    return this.mapCustomer(item);
   };
 
   registerVisit = async (email: string, date: Date): Promise<void> => {


### PR DESCRIPTION
Hi team!

Previously, when the email was not found in the DB, this service returned a 404 response.

Now, it returns a 200 OK with an empty object with the object key:

```
### Request
GET lambdas-poc/notfound@email.com

### Response
{
  "email": "notfound@email.com",
  "lastVisit": null
}
```

I think that it is the expected behavior since we can register visits from new emails, for example: 

```
### Request 1 (at 2022-10-25T13:39:34.707Z)
POST lambdas-poc/newcustomer@email.com/visit

### Request 2
GET lambdas-poc/newcustomer@email.com

### Response 2
{
  "email": "newcustomer@email.com",
  "lastVisit": "2022-10-25T13:39:34.707Z"
}
```